### PR TITLE
Ability to add extra docker compose up args

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,7 @@ services:
 ## Pre compose up script
 
 Sometimes, you may need some logic to run before the compose test containers come up. You can use `pre_compose_up_script` for that purpose. See [examples/pre-compose-up-script-test](examples/pre-compose-up-script-test) for an example.
+
+## extra_docker_compose_up_args
+
+You can append extra arguments to the `docker compose up` command using `extra_docker_compose_up_args`. See [examples/pre-compose-up-script-test](examples/pre-compose-up-script-test) for an example.

--- a/docker_compose/docker_compose_test.bzl
+++ b/docker_compose/docker_compose_test.bzl
@@ -28,6 +28,7 @@ def docker_compose_test(
     docker_compose_file,
     docker_compose_test_container,
     pre_compose_up_script = "",
+    extra_docker_compose_up_args = "",
     local_image_targets = "",
     data = [],
     tags = [],
@@ -40,7 +41,7 @@ def docker_compose_test(
     native.sh_test(
         name = name,
         srcs = ["@rules_docker_compose//docker_compose:docker_compose_test.sh"],
-        env = _get_env(docker_compose_file, local_image_targets, docker_compose_test_container, pre_compose_up_script),
+        env = _get_env(docker_compose_file, local_image_targets, docker_compose_test_container, pre_compose_up_script, extra_docker_compose_up_args),
         size = size,
         tags = tags,
         data = data,
@@ -53,6 +54,7 @@ def junit_docker_compose_test(
     docker_compose_file,
     docker_compose_test_container,
     pre_compose_up_script = "",
+    extra_docker_compose_up_args = "",
     local_image_targets = "",
     classpath_jars = [],
     test_image_base = None,
@@ -132,7 +134,7 @@ def junit_docker_compose_test(
     native.sh_test(
         name = name,
         srcs = ["@rules_docker_compose//docker_compose:docker_compose_test.sh"],
-        env = _get_env(docker_compose_file, local_image_targets, docker_compose_test_container, pre_compose_up_script),
+        env = _get_env(docker_compose_file, local_image_targets, docker_compose_test_container, pre_compose_up_script, extra_docker_compose_up_args),
         size = size,
         tags = tags,
         data = data,
@@ -140,12 +142,13 @@ def junit_docker_compose_test(
     )
 
 
-def _get_env(docker_compose_file, local_image_targets, docker_compose_test_container, pre_compose_up_script):
+def _get_env(docker_compose_file, local_image_targets, docker_compose_test_container, pre_compose_up_script, extra_docker_compose_up_args):
     env = {
         "WORKSPACE_PATH": BUILD_WORKSPACE_DIRECTORY,
         "DOCKER_COMPOSE_FILE": "$(location " + docker_compose_file + ")",
         "LOCAL_IMAGE_TARGETS": local_image_targets.replace(":", "/"),
         "DOCKER_COMPOSE_TEST_CONTAINER": docker_compose_test_container,
+        "EXTRA_DOCKER_COMPOSE_UP_ARGS": extra_docker_compose_up_args,
     }
 
     if len(pre_compose_up_script):

--- a/docker_compose/docker_compose_test.sh
+++ b/docker_compose/docker_compose_test.sh
@@ -48,7 +48,9 @@ fi
 ABSOLUTE_COMPOSE_FILE_PATH=$WORKSPACE_PATH/$DOCKER_COMPOSE_FILE
 
 # bring up compose file & get exit status-code from the integration test container
-docker-compose -f $ABSOLUTE_COMPOSE_FILE_PATH up --exit-code-from $DOCKER_COMPOSE_TEST_CONTAINER
+docker_compose_up_cmd="docker-compose -f $ABSOLUTE_COMPOSE_FILE_PATH up --exit-code-from $DOCKER_COMPOSE_TEST_CONTAINER $EXTRA_DOCKER_COMPOSE_UP_ARGS"
+echo "running: $docker_compose_up_cmd"
+echo "$docker_compose_up_cmd" | bash
 result=$?
 docker-compose -f $ABSOLUTE_COMPOSE_FILE_PATH down
 exit $result

--- a/examples/pre-compose-up-script-test/BUILD
+++ b/examples/pre-compose-up-script-test/BUILD
@@ -19,5 +19,6 @@ docker_compose_test(
     name = "pre-compose-up-script-test",
     docker_compose_file = ":docker-compose.yml",
     docker_compose_test_container = "test_container",
-    pre_compose_up_script = ":src/test/resources/setup_test.sh"
+    pre_compose_up_script = ":src/test/resources/setup_test.sh",
+    extra_docker_compose_up_args = "--no-color",
 )


### PR DESCRIPTION
You can now append extra arguments to the `docker compose <docker-compose-file> up` command using `extra_docker_compose_up_args`.

For example, `docker compose <docker-compose-file> up --no-color`