### PR TITLE
Make it possible for JAVA_HOME to be dynamic

### DIFF
--- a/docker_compose/test_container_entrypoint.sh
+++ b/docker_compose/test_container_entrypoint.sh
@@ -13,8 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# if JAVA_HOME is not set, just default to /usr (works if /usr/bin/java exists)
 if [[ -z "$JAVA_HOME" ]]; then
     JAVA_HOME="/usr"
+# this is used if JAVA_HOME contains an * (if version changes regularly this can be useful)
+elif [[ "$JAVA_HOME" == *"\*"* ]]; then
+    JAVA_HOME=$(find $JAVA_HOME -maxdepth 1 | head -n 1)
 fi
 
 TEST_UBER_JAR=$(find ./ -maxdepth 1 -name '*_uber_jar_deploy.jar')

--- a/examples/junit-image-test/docker-compose.yml
+++ b/examples/junit-image-test/docker-compose.yml
@@ -17,3 +17,5 @@ services:
   test_container:
     image: junit-image-test:test_container
     entrypoint: ["/busybox/sh", "./test_container_entrypoint.sh"]
+    environment:
+      - JAVA_HOME=/usr/


### PR DESCRIPTION
In some cases, the path to JAVA_HOME would change quite often e.g. if the version is swapped out regularly. This change means that you don't need to keep changing the value of JAVA_HOME in your docker-compose files, you can just use a `*`.