### PR TITLE
including runfiles in the classpath_jars tar so transitive jars are also brought in

### DIFF
--- a/docker_compose/docker_compose_test.bzl
+++ b/docker_compose/docker_compose_test.bzl
@@ -94,6 +94,7 @@ def junit_docker_compose_test(
         name = name + "_required_classpath_jars_tar",
         srcs = classpath_jars,
         testonly = True,
+        include_runfiles = True,
     )
 
     # this is what actually runs the junit jar for your test execution


### PR DESCRIPTION
For advanced `junit_docker_compose_test`, both jars and their transitives are needed in the image at test time.